### PR TITLE
feat: Add support for group instance in dataset methods

### DIFF
--- a/pbipy/powerbi.py
+++ b/pbipy/powerbi.py
@@ -1,5 +1,5 @@
 """
-Module implements a Power BI client that wraps around the Power BI Rest 
+Module implements a Power BI client that wraps around the Power BI Rest
 API.
 
 Full API documentation can be found at:
@@ -422,11 +422,10 @@ class PowerBI:
             self.session,
         )
 
-    # TODO: Add support for passing in a group obj
     def dataset(
         self,
         dataset: str | Dataset,
-        group: str = None,
+        group: str | Group = None,
     ) -> Dataset:
         """
         Return the specified dataset from MyWorkspace or the specified
@@ -436,8 +435,8 @@ class PowerBI:
         ----------
         `dataset` : `str | Dataset`
             Dataset Id of the dataset to retrieve.
-        `group` : `str`, optional
-            Group Id where the dataset resides., by default None
+        `group` : `str | Group`, optional
+            Group Id or `Group` object where the dataset resides, by default None.
 
         Returns
         -------
@@ -449,22 +448,27 @@ class PowerBI:
         if isinstance(dataset, Dataset):
             return dataset
 
-        dataset = Dataset(dataset, self.session, group_id=group)
+        if isinstance(group, Group):
+            group_id = group.id
+        else:
+            group_id = group
+
+        dataset = Dataset(dataset, self.session, group_id=group_id)
         dataset.load()
 
         return dataset
 
     def datasets(
         self,
-        group: str = None,
+        group: str | Group = None,
     ) -> list[Dataset]:
         """
         Returns a list of datasets from MyWorkspace or the specified group.
 
         Parameters
         ----------
-        `group` : str, optional
-            Group Id where the datasets reside. If not supplied, then datasets
+        `group` : `str | Group`, optional
+            Group Id or `Group` object where the datasets reside. If not supplied, then datasets
             will be retrieved from MyWorkspace.
 
         Returns
@@ -473,9 +477,13 @@ class PowerBI:
             List of datasets for MyWorkspace or the specified group.
 
         """
+        if isinstance(group, Group):
+            group_id = group.id
+        else:
+            group_id = group
 
-        if group:
-            path = f"/groups/{group}/datasets"
+        if group_id:
+            path = f"/groups/{group_id}/datasets"
         else:
             path = "/datasets"
 
@@ -489,7 +497,7 @@ class PowerBI:
             Dataset(
                 dataset_js.get("id"),
                 self.session,
-                group_id=group,
+                group_id=group_id,
                 raw=dataset_js,
             )
             for dataset_js in raw
@@ -500,7 +508,7 @@ class PowerBI:
     def delete_dataset(
         self,
         dataset: str | Dataset,
-        group: str = None,
+        group: str | Group = None,
     ) -> None:
         """
         Delete the specified dataset from MyWorkspace or the specified
@@ -510,8 +518,8 @@ class PowerBI:
         ----------
         `dataset` : `str | Dataset`
             Dataset Id or `Dataset` object to delete.
-        `group` : `str`, optional
-            Group Id where the dataset resides., by default None
+        `group` : `str | Group`, optional
+            Group Id or `Group` object where the dataset resides, by default None
 
         Raises
         ------
@@ -526,8 +534,13 @@ class PowerBI:
         else:
             dataset_id = dataset
 
-        if group:
-            path = f"/groups/{group}/datasets/{dataset_id}"
+        if isinstance(group, Group):
+            group_id = group.id
+        else:
+            group_id = group
+
+        if group_id:
+            path = f"/groups/{group_id}/datasets/{dataset_id}"
         else:
             path = f"/datasets/{dataset_id}"
 
@@ -917,7 +930,7 @@ class PowerBI:
         ------
         `Exception`
             If an error was encountered during the import process.
-        
+
         See Also
         --------
         `PowerBI.import_large_file`

--- a/tests/test_powerbi.py
+++ b/tests/test_powerbi.py
@@ -77,6 +77,24 @@ def test_get_dataset_group_property_is_set(powerbi, get_dataset):
 
 
 @responses.activate
+def test_get_dataset_calls_correct_get_dataset_in_group_instance(powerbi, get_dataset):
+    responses.get(
+        "https://api.powerbi.com/v1.0/myorg/groups/f089354e-8366-4e18-aea3-4cb4a3a50b48/datasets/cfafbeb1-8037-4d0c-896e-a46fb27ff229",
+        body=get_dataset,
+        content_type="application/json",
+    )
+
+    group = Group(id="f089354e-8366-4e18-aea3-4cb4a3a50b48", session=requests.Session())
+
+    dataset = powerbi.dataset(
+        "cfafbeb1-8037-4d0c-896e-a46fb27ff229",
+        group=group,
+    )
+
+    assert dataset.group_id == group.id
+
+
+@responses.activate
 def test_get_datasets_calls_correct_get_datasets_url(powerbi, get_datasets):
     responses.get(
         "https://api.powerbi.com/v1.0/myorg/datasets",
@@ -129,6 +147,23 @@ def test_get_datasets_sets_js_property(powerbi, get_datasets):
 
 
 @responses.activate
+def test_get_datasets_calls_correct_get_datasets_in_group_instance(
+    powerbi, get_datasets
+):
+    responses.get(
+        "https://api.powerbi.com/v1.0/myorg/groups/f089354e-8366-4e18-aea3-4cb4a3a50b48/datasets",
+        body=get_datasets,
+        content_type="application/json",
+    )
+
+    group = Group(id="f089354e-8366-4e18-aea3-4cb4a3a50b48", session=requests.Session())
+
+    datasets = powerbi.datasets(group=group)
+
+    assert all(hasattr(dataset, "raw") for dataset in datasets)
+
+
+@responses.activate
 def test_delete_dataset_call(powerbi):
     responses.delete(
         "https://api.powerbi.com/v1.0/myorg/groups/f089354e-8366-4e18-aea3-4cb4a3a50b48/datasets/cfafbeb1-8037-4d0c-896e-a46fb27ff229"
@@ -137,6 +172,20 @@ def test_delete_dataset_call(powerbi):
     powerbi.delete_dataset(
         "cfafbeb1-8037-4d0c-896e-a46fb27ff229",
         group="f089354e-8366-4e18-aea3-4cb4a3a50b48",
+    )
+
+
+@responses.activate
+def test_delete_dataset_call_from_group_instance(powerbi):
+    responses.delete(
+        "https://api.powerbi.com/v1.0/myorg/groups/f089354e-8366-4e18-aea3-4cb4a3a50b48/datasets/cfafbeb1-8037-4d0c-896e-a46fb27ff229"
+    )
+
+    group = Group(id="f089354e-8366-4e18-aea3-4cb4a3a50b48", session=requests.Session())
+
+    powerbi.delete_dataset(
+        "cfafbeb1-8037-4d0c-896e-a46fb27ff229",
+        group=group,
     )
 
 


### PR DESCRIPTION
I tried passing in a group instance to the dataset methods and it threw errors on my end. Added support for unwrapping Ids from group instances

Changes
- Updated powerbi.py to support passing group instance for dataset, datasets, and delete_dataset
- Modified test_powerbi.py to include tests for new group instance functionality
- Other changes were due to Black formatting